### PR TITLE
Portfolio: Preserve data in the browser (localStorage)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/index.html
+++ b/index.html
@@ -131,14 +131,14 @@
     <form id="contact-form" action="https://formspree.io/f/mayvvvrn" method="post" class="contact-form">
       <ul class="contact-inputs">
         <li>
-          <input class="small-text" type="text" name="user_name" placeholder="First and Last Name" maxlength="30"
+          <input class="small-text" id="name-input" type="text" name="user_name" placeholder="First and Last Name" maxlength="30"
             required>
         </li>
         <li>
           <input class="small-text" type="email" id="email-at" name="user_email" placeholder="example1@gmail.com" required>
         </li>
         <li>
-          <textarea class="msg" name="user_message" maxlength="500" placeholder="Enter the message here" rows="9"
+          <textarea class="msg" id="msg-input" name="user_message" maxlength="500" placeholder="Enter the message here" rows="9"
             required></textarea>
         </li>
         <li class="submit-container">

--- a/index.js
+++ b/index.js
@@ -257,3 +257,32 @@ submitBtn.onclick = (event) => {
     event.preventDefault();
   }
 };
+
+// LocalStorage input data preservation
+const inputFields = document.getElementById('contact');
+const nameInput = document.getElementById('name-input');
+const msgInput = document.getElementById('msg-input');
+
+inputFields.addEventListener('input', () => {
+  const nameValue =  nameInput.value;
+  const email = emailInput.value;
+  const msg = msgInput.value;
+
+  // make email format error disappear with new entry
+  error.textContent = '';
+  emailInput.classList.remove('email-error-msg');
+
+
+  if (!nameValue && !email && !msg) {
+    return;
+  }
+
+  inputData = {
+    nameValue,
+    email,
+    msg,
+  }
+
+  localStorage.setItem('inputData', JSON.stringify(inputData));
+});
+

--- a/index.js
+++ b/index.js
@@ -263,15 +263,16 @@ const inputFields = document.getElementById('contact');
 const nameInput = document.getElementById('name-input');
 const msgInput = document.getElementById('msg-input');
 
+let inputData;
+
 inputFields.addEventListener('input', () => {
-  const nameValue =  nameInput.value;
+  const nameValue = nameInput.value;
   const email = emailInput.value;
   const msg = msgInput.value;
 
   // make email format error disappear with new entry
   error.textContent = '';
   emailInput.classList.remove('email-error-msg');
-
 
   if (!nameValue && !email && !msg) {
     return;
@@ -281,8 +282,16 @@ inputFields.addEventListener('input', () => {
     nameValue,
     email,
     msg,
-  }
+  };
 
   localStorage.setItem('inputData', JSON.stringify(inputData));
 });
 
+inputData = JSON.parse(localStorage.getItem('inputData'));
+
+// Data Store in localStorage
+if (inputData) {
+  nameInput.value = inputData.nameValue;
+  emailInput.value = inputData.email;
+  msgInput.value = inputData.msg;
+}


### PR DESCRIPTION
## Store Form's Inputs data with LocalStorage :card_file_box: 

These are the proposed changes :recycle: for the project :bulb: 
- Added `.addEventListener()` for the contact :bust_in_silhouette: section to activate for the inputs and create the object to store the data :arrow_right: :open_file_folder: 
- Added and if statement to store the data even when changed :heavy_check_mark: 
- Disabled validation error when the user types another entry :exclamation: 

**[IMPORTANT]**: The Webhint linter error shown in the Github actions is not showing when running the command `npx hint .`

![Screenshot from 2022-06-17 11-48-34](https://user-images.githubusercontent.com/92395484/174346632-17d2fd9f-9a8b-47ba-8a9b-235d7f20e67e.png)

Please take this into consideration :smiley: 


